### PR TITLE
fix: add correct license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/lewiscowper/shitty.men/issues"
   },


### PR DESCRIPTION
The repo itself says "MIT" so I thought I'd make the package.json match.